### PR TITLE
Remove tabs and eol spaces, even-out spacing in configuration declaration

### DIFF
--- a/configuration.k
+++ b/configuration.k
@@ -10,18 +10,18 @@ syntax START
 configuration
     <k> $PGM:START </k>
     <exit-code exit=""> 0 </exit-code>
-    // ... 
-    
+    // ...
+
     <ethereum>
-        
+
         // Solidity execution engine
         // =========================
-        
-        <solidity> 
-            
+
+        <solidity>
+
             // Mutable during a single transaction
             // -----------------------------------
-            
+
             <execEngine>
                 <output>          .K  </output>
                 <statusCode>      .K  </statusCode>
@@ -29,11 +29,11 @@ configuration
                 <interimStates>   .List  </interimStates>
                 <touchedAccounts> .K  </touchedAccounts>
                 <currentAccount>  #account(-1, #Testing-Engine#)  </currentAccount>
-		        <result> .K </result>
-		        <mode> .K </mode>
+                   <result> .K </result>
+                   <mode> .K </mode>
 
                 <callState>
-                
+
                     // Should be loaded from <account>
                     <program> .K </program>              // currently running <contract>
 
@@ -45,26 +45,26 @@ configuration
 
                     // \mu_*
                     // env: map from qualified name to either storage or local memory
-                    // QName ::= Id | Id.Id /* struct member */ | ... 
+                    // QName ::= Id | Id.Id /* struct member */ | ...
                     // Reference ::= storage(Index, Offset)  // Index, Offset are Word a.k.a. uint256
                     //             | memory(Index, Offset)
                     <env> .Map </env>     // Map of names to references
-                
+
                     // tenv: map from qualified name to type
                     // where Type ::= uintXX ... | array | struct(members) | ...
                     <tenv> .Map </tenv>         // Map names to types
-                
+
                     // memory: same as evm!!
                     // exact allocation strategy may vary(unlike storage), but anyway semantics should be indentical
-                    <localMem> .Map </localMem> 
-                    
-                    // Gas: not sure how, but I think we need it. 
+                    <localMem> .Map </localMem>
+
+                    // Gas: not sure how, but I think we need it.
                     <gas>         0:Int          </gas>
                     <memoryUsed>  0:Int          </memoryUsed>
                     <previousGas> 0:Int          </previousGas>
 
-                    // Those are present in both KEVM and IELE. 
-                    // Not sure we need them, let's keep them around until figure it out. 
+                    // Those are present in both KEVM and IELE.
+                    // Not sure we need them, let's keep them around until figure it out.
                     <static>    false:Bool     </static>
                     <callDepth>   0    </callDepth>
 
@@ -88,7 +88,7 @@ configuration
                 <origin>   0 </origin>                            // I_o
 
                 // I_H* (block information)
-                // Needed or not? It is part of KEEI, but not sure. Should discuss. 
+                // Needed or not? It is part of KEEI, but not sure. Should discuss.
                 <block>
                     <hashes>           .List      </hashes>
                     <coinbase>         0          </coinbase>         // H_c
@@ -99,40 +99,40 @@ configuration
                     <timestamp>        0          </timestamp>        // H_s
                 </block>
             </execEngine>
-            
-            // This is the part of the "Solidity VM" where we keep the available contracts. 
+
+            // This is the part of the "Solidity VM" where we keep the available contracts.
             // Those are either obtained from source file (creation) or loaded from accounts (function call).
 
-            // When we parse Solidity source file we 
-            //   - desugar/preprocess modifiers, inheritance (?) etc. 
+            // When we parse Solidity source file we
+            //   - desugar/preprocess modifiers, inheritance (?) etc.
             //   - create one <contract> structure for each contract declared in the sources
             // (let's not worry about those for now, and just stick to simple functions)
 
-            // From here, <contract>s can be either deployed or executed. 
-            // When a contract is deployed we not only copy its <contract> cell into the <account>, 
-            // but we also copy the other contracts that were present in the same source file, 
-            // so that the deployed contract have access to them and can create and deploy them if needed. 
+            // From here, <contract>s can be either deployed or executed.
+            // When a contract is deployed we not only copy its <contract> cell into the <account>,
+            // but we also copy the other contracts that were present in the same source file,
+            // so that the deployed contract have access to them and can create and deploy them if needed.
             // (see the <account> cell below for more notes about this)
 
             <contracts>
                 <Contract multiplicity = "*" type="Map">
                     <cname> .K </cname>
-                    
+
                     <functions>
                         <Function multiplicity="*" type="Map">
                             <fname>         .K         </fname>
-                            <inputParams>  .K         </inputParams> 
+                            <inputParams>  .K         </inputParams>
                             <Returns>      .K         </Returns>
                             <quantifiers>  .K         </quantifiers>
                             <visibility>   .K         </visibility> // Visibility ::= public | privat
                             <body> .K </body>
                         </Function>
                     </functions>
-		            
+
                     <stateVar> .List </stateVar>
                     <Constructor> false </Constructor>
                     // ... more to be added later ...
-                
+
                 </Contract>
             </contracts>
 
@@ -147,31 +147,31 @@ configuration
             // ---------------
 
             <activeAccounts> .Set </activeAccounts>
-	        
+
             // removed becuase we can get this number by size(activeAccounts).
             //<numOfAccounts> 0:Int </numOfAccounts>
-            
+
             <accounts>
                 <account multiplicity="*" type="Map">
-                    
+
                     // Same as in KEVM / IELE
-                    
+
                     <acctID>  .K                      </acctID>
                     <balance> 0                      </balance>
 
 
 
-                    // The <acctEnv> cell refers to the environment, mapping variable names to logical 
+                    // The <acctEnv> cell refers to the environment, mapping variable names to logical
                     // storage references. Actually, <acctEnv> is equivalent to the <env> cell in <execEngine>.
 
-		            <acctEnv> .Map		     </acctEnv>
-                    
+                       <acctEnv> .Map             </acctEnv>
+
                     // When a contract is deployed, its <contract> data structure will be copied here.
-                    // Because contracts can create other contracts (via "new") we need to also keep the 
+                    // Because contracts can create other contracts (via "new") we need to also keep the
                     // set of contract that this contract can create (i.e. the set of contracts that was
                     // available at creation time, like in IELE)
 
-                    <code> 
+                    <code>
                         <associatedContract> .K </associatedContract>    // contract deployed on this account
                         <availableContracts> .K </availableContracts>    // contracts that can be created by this account's contract
                     </code>
@@ -182,11 +182,11 @@ configuration
                     // variable and I think these rules should be the part of Solidity semantics,
                     // so that the storage usage of solidity program and evm bytecode have
                     // the same effect on the storage.
-                    
+
                     <acctStorage> .Map  </acctStorage>
 
                     // Q. Why include allocation rules in solidity semantics?
-                    // A. 
+                    // A.
                     // * These rules are explained in the offical solidity docs
                     // https://solidity.readthedocs.io/en/v0.4.24/miscellaneous.html?highlight=pack#layout-of-state-variables-in-storage
                     // * AFAIK, allocation is not affected by optimization level.
@@ -196,7 +196,7 @@ configuration
                     //
 
                     <nonce>   0:Int             </nonce>
-                
+
                 </account>
             </accounts>
 
@@ -207,8 +207,8 @@ configuration
             <txPending> .List </txPending>
 
             // Borrowed from IELE. Notice this is more high level than KEVM
-            // May need further tweaks, but that's the idea. 
-           
+            // May need further tweaks, but that's the idea.
+
             <messages>
                 <message multiplicity="*">
                 <msgID>      0          </msgID>              // Unique ID of transaction
@@ -220,7 +220,7 @@ configuration
                 <value>      0          </value>              // Value in funds to transfer by transaction
                 <from>       0          </from>               // Sender of transaction
                 <data>       .K         </data>               // .WordStack Arguments to function called by transaction
-                <args>       .K      </args>		      //.Ints
+                   <args>       .K      </args>              //.Ints
                 </message>
             </messages>
 

--- a/configuration.k
+++ b/configuration.k
@@ -23,14 +23,14 @@ configuration
             // -----------------------------------
 
             <execEngine>
-                <output>          .K  </output>
-                <statusCode>      .K  </statusCode>
-                <callStack>     .List  </callStack>
-                <interimStates>   .List  </interimStates>
-                <touchedAccounts> .K  </touchedAccounts>
-                <currentAccount>  #account(-1, #Testing-Engine#)  </currentAccount>
-                   <result> .K </result>
-                   <mode> .K </mode>
+                <output>          .K                             </output>
+                <statusCode>      .K                             </statusCode>
+                <callStack>       .List                          </callStack>
+                <interimStates>   .List                          </interimStates>
+                <touchedAccounts> .K                             </touchedAccounts>
+                <currentAccount>  #account(-1, #Testing-Engine#) </currentAccount>
+                <result>          .K                             </result>
+                <mode>            .K                             </mode>
 
                 <callState>
 
@@ -38,10 +38,10 @@ configuration
                     <program> .K </program>              // currently running <contract>
 
                     // I_*
-                    <id>        0          </id>         // Currently executing contract
-                    <caller>    .K          </caller>     // Contract that called current contract
-                    <callData>  .K         </callData>   // .WordStack Copy of register arguments (?)
-                    <callValue>  0          </callValue>  // Value in funds passed to contract
+                    <id>         0 </id>        // Currently executing contract
+                    <caller>    .K </caller>    // Contract that called current contract
+                    <callData>  .K </callData>  // .WordStack Copy of register arguments (?)
+                    <callValue>  0 </callValue> // Value in funds passed to contract
 
                     // \mu_*
                     // env: map from qualified name to either storage or local memory
@@ -59,17 +59,17 @@ configuration
                     <localMem> .Map </localMem>
 
                     // Gas: not sure how, but I think we need it.
-                    <gas>         0:Int          </gas>
-                    <memoryUsed>  0:Int          </memoryUsed>
-                    <previousGas> 0:Int          </previousGas>
+                    <gas>         0:Int </gas>
+                    <memoryUsed>  0:Int </memoryUsed>
+                    <previousGas> 0:Int </previousGas>
 
                     // Those are present in both KEVM and IELE.
                     // Not sure we need them, let's keep them around until figure it out.
-                    <static>    false:Bool     </static>
-                    <callDepth>   0    </callDepth>
+                    <static>    false:Bool </static>
+                    <callDepth> 0          </callDepth>
 
-                    <returnFlag> false:Bool </returnFlag>
-                    <returnValue> 0:Value </returnValue>
+                    <returnFlag>             false:Bool </returnFlag>
+                    <returnValue>            0:Value    </returnValue>
                     <isExternalFunctionCall> false:Bool </isExternalFunctionCall>
                 </callState>
 
@@ -90,13 +90,13 @@ configuration
                 // I_H* (block information)
                 // Needed or not? It is part of KEEI, but not sure. Should discuss.
                 <block>
-                    <hashes>           .List      </hashes>
-                    <coinbase>         0          </coinbase>         // H_c
-                    // <logsBloom>        .WordStack </logsBloom>        // H_b
-                    <difficulty>       0          </difficulty>       // H_d
-                    <number>           0          </number>           // H_i
-                    <gasLimit>         0          </gasLimit>         // H_l
-                    <timestamp>        0          </timestamp>        // H_s
+                    <hashes>     .List      </hashes>
+                    <coinbase>   0          </coinbase>   // H_c
+                    // <logsBloom>  .WordStack </logsBloom>  // H_b
+                    <difficulty> 0          </difficulty> // H_d
+                    <number>     0          </number>     // H_i
+                    <gasLimit>   0          </gasLimit>   // H_l
+                    <timestamp>  0          </timestamp>  // H_s
                 </block>
             </execEngine>
 
@@ -120,12 +120,12 @@ configuration
 
                     <functions>
                         <Function multiplicity="*" type="Map">
-                            <fname>         .K         </fname>
-                            <inputParams>  .K         </inputParams>
-                            <Returns>      .K         </Returns>
-                            <quantifiers>  .K         </quantifiers>
-                            <visibility>   .K         </visibility> // Visibility ::= public | privat
-                            <body> .K </body>
+                            <fname>       .K </fname>
+                            <inputParams> .K </inputParams>
+                            <Returns>     .K </Returns>
+                            <quantifiers> .K </quantifiers>
+                            <visibility>  .K </visibility> // Visibility ::= public | privat
+                            <body>        .K </body>
                         </Function>
                     </functions>
 
@@ -156,15 +156,13 @@ configuration
 
                     // Same as in KEVM / IELE
 
-                    <acctID>  .K                      </acctID>
-                    <balance> 0                      </balance>
-
-
+                    <acctID>  .K </acctID>
+                    <balance>  0 </balance>
 
                     // The <acctEnv> cell refers to the environment, mapping variable names to logical
                     // storage references. Actually, <acctEnv> is equivalent to the <env> cell in <execEngine>.
 
-                       <acctEnv> .Map             </acctEnv>
+                    <acctEnv> .Map </acctEnv>
 
                     // When a contract is deployed, its <contract> data structure will be copied here.
                     // Because contracts can create other contracts (via "new") we need to also keep the
@@ -183,7 +181,7 @@ configuration
                     // so that the storage usage of solidity program and evm bytecode have
                     // the same effect on the storage.
 
-                    <acctStorage> .Map  </acctStorage>
+                    <acctStorage> .Map </acctStorage>
 
                     // Q. Why include allocation rules in solidity semantics?
                     // A.
@@ -195,7 +193,7 @@ configuration
                     // https://github.com/gnosis/safe-contracts/blob/d279480b0be2562aab7dd0a751113ba8681e816e/contracts/proxies/Proxy.sol
                     //
 
-                    <nonce>   0:Int             </nonce>
+                    <nonce> 0:Int </nonce>
 
                 </account>
             </accounts>
@@ -211,16 +209,16 @@ configuration
 
             <messages>
                 <message multiplicity="*">
-                <msgID>      0          </msgID>              // Unique ID of transaction
-                <txNonce>    0          </txNonce>            // Nonce of transaction (not checked)
-                <txGasPrice> 0          </txGasPrice>         // Gas price of transaction
-                <txGasLimit> 0          </txGasLimit>         // Gas limit of transaction
-                <sendto>     .K   </sendto>             // Destination of transaction (.Account for account creation)
-                <func>       .K    </func>               // Function to call by transaction
-                <value>      0          </value>              // Value in funds to transfer by transaction
-                <from>       0          </from>               // Sender of transaction
-                <data>       .K         </data>               // .WordStack Arguments to function called by transaction
-                   <args>       .K      </args>              //.Ints
+                <msgID>       0 </msgID>      // Unique ID of transaction
+                <txNonce>     0 </txNonce>    // Nonce of transaction (not checked)
+                <txGasPrice>  0 </txGasPrice> // Gas price of transaction
+                <txGasLimit>  0 </txGasLimit> // Gas limit of transaction
+                <sendto>     .K </sendto>     // Destination of transaction (.Account for account creation)
+                <func>       .K </func>       // Function to call by transaction
+                <value>       0 </value>      // Value in funds to transfer by transaction
+                <from>        0 </from>       // Sender of transaction
+                <data>       .K </data>       // .WordStack Arguments to function called by transaction
+                <args>       .K </args>       //.Ints
                 </message>
             </messages>
 

--- a/contract.k
+++ b/contract.k
@@ -18,9 +18,9 @@ rule [ContractDefinition]:
      <k> contract C:Id { Cs:ContractParts } => #pcsContractParts(C,Cs) ...  </k>
      (.Bag =>
        <Contract>
-	  <cname> C </cname>
-	  <functions> .Bag </functions>
-	  <stateVar> .List </stateVar>
+      <cname> C </cname>
+      <functions> .Bag </functions>
+      <stateVar> .List </stateVar>
           ...
        </Contract>
      )
@@ -32,20 +32,20 @@ syntax SolidityItem
 
 rule #pcsContractParts(Ct:Id, .ContractParts) => .
 rule #pcsContractParts(Ct:Id, C:ContractPart Cs:ContractParts) =>
-     	   #pcsContractPart(Ct, C) ~> #pcsContractParts(Ct,Cs)
+               #pcsContractPart(Ct, C) ~> #pcsContractParts(Ct,Cs)
 
 rule [StateVariableDeclaration]:
      <k> #pcsContractPart(C:Id, T:TypeName F:FunQuantifiers V:Id;) =>
-     	  . ...</k>
+              . ...</k>
      <Contract>
          <cname> C </cname>
          <stateVar> ... .List => ListItem(#varInfo(V, #undef_Value, T, #storage)) </stateVar>
          ...
      </Contract>
 
-rule 
+rule
      <k> #pcsContractPart(C:Id, T:TypeName F:FunQuantifiers V:Id = E;) =>
-     	  . ...</k>
+              . ...</k>
      <Contract>
          <cname> C </cname>
          <stateVar> ... .List => ListItem(#varInfo(V, E, T, #storage)) </stateVar>
@@ -61,7 +61,7 @@ rule
     <currentAccount> #account(C:Int, CN:AccountId) </currentAccount>
 
 syntax SolidityItem
-       ::= #createStateVars(Int, Id, List) 
+       ::= #createStateVars(Int, Id, List)
          | #exeConstructor(Id,Int,ExpressionList) [strict(3)]
 
 rule [New-Contract-Instance]:
@@ -77,16 +77,16 @@ rule [New-Contract-Instance]:
     ...
     (.Bag =>
         <account>
-	        <acctID> #account(size(AA),C) </acctID>
-	        <balance> 0 </balance>
+            <acctID> #account(size(AA),C) </acctID>
+            <balance> 0 </balance>
             <acctEnv> .Map </acctEnv>
             <code>
-	            <associatedContract> .K </associatedContract>
-	            <availableContracts> .K </availableContracts>
+                <associatedContract> .K </associatedContract>
+                <availableContracts> .K </availableContracts>
             </code>
-	        <acctStorage> .Map </acctStorage>
-	        <nonce> 0 </nonce>
-	        ...
+            <acctStorage> .Map </acctStorage>
+            <nonce> 0 </nonce>
+            ...
         </account>
     )
     </accounts>
@@ -95,7 +95,7 @@ rule #createStateVars(N:Int, CN:Id, ListItem(VInfo) L:List) => #allocate(N, CN, 
 
 rule #createStateVars(N:Int, CN:Id, .List) => .
 
-rule 
+rule
      <k> #exeConstructor(C:Id,N:Int,Es:Values) => functionCall(N;String2Id("constructor"); Es); ... </k>
      <Contract>
          <cname> C </cname>
@@ -103,7 +103,7 @@ rule
          ...
      </Contract>
 
-rule 
+rule
      <k> #exeConstructor(C:Id,N:Int,Es:Values) => . ... </k>
      <Contract>
          <cname> C </cname>

--- a/driver.k
+++ b/driver.k
@@ -16,11 +16,11 @@ syntax JSONKey
 syntax JSON
        ::= String
          | JSONKey  ":" JSON
-	 | "{" JSONList "}"
-	 | "[" JSONList "]"
-	 | #solidity(Statements)
-	 | #solidity(Expression)
-	 | MemStatusList
+     | "{" JSONList "}"
+     | "[" JSONList "]"
+     | #solidity(Statements)
+     | #solidity(Expression)
+     | MemStatusList
 
 syntax MemStatusList
        ::= List{MemStatus, ""}
@@ -33,8 +33,8 @@ syntax JSONList
 
 syntax SolidityCommand
        ::= "#check" JSON
- 	 | "#run" JSON		//this is the test command
-	
+         | "#run" JSON        //this is the test command
+
 syntax SolidityCommand
        ::= "#success"
          | "#failure" String
@@ -49,30 +49,30 @@ syntax SoliditySimulation
 syntax SoliditySimulation
        ::= JSON
 
-syntax JSONList 
+syntax JSONList
        ::= #sortJSONList ( JSONList )            [function]
          | #sortJSONList ( JSONList , JSONList ) [function, klabel(#sortJSONListAux)]
 
 rule #sortJSONList(JS) => #sortJSONList(JS, .JSONList)
 rule #sortJSONList(.JSONList, LS)            => LS
-rule #sortJSONList(((KEY : VAL) , REST), LS) 
+rule #sortJSONList(((KEY : VAL) , REST), LS)
      => #insertJSONKey((KEY : VAL), #sortJSONList(REST, LS))
 
-syntax JSONList ::= #insertJSONKey ( JSON , JSONList )		[function]
+    yntax JSONList ::= #insertJSONKey ( JSON , JSONList )        [function]
 rule #insertJSONKey( JS , .JSONList ) => JS , .JSONList
-rule #insertJSONKey( (KEY : VAL) , ((KEY' : VAL') , REST) ) 
-     => (KEY : VAL)   , (KEY' : VAL'), REST  
+rule #insertJSONKey( (KEY : VAL) , ((KEY' : VAL') , REST) )
+     => (KEY : VAL)   , (KEY' : VAL'), REST
      requires KEY <String KEY'
 
-rule #insertJSONKey( (KEY : VAL) , ((KEY' : VAL') , REST) ) 
-     => (KEY' : VAL') , #insertJSONKey((KEY : VAL) , REST) 
+rule #insertJSONKey( (KEY : VAL) , ((KEY' : VAL') , REST) )
+     => (KEY' : VAL') , #insertJSONKey((KEY : VAL) , REST)
      requires KEY >=String KEY'
 
 syntax Bool ::= #isSorted ( JSONList ) [function]
  // -------------------------------------------------
 rule #isSorted( .JSONList ) => true
 rule #isSorted( KEY : _ )   => true
-rule #isSorted( (KEY : _) , (KEY' : VAL) , REST ) => 
+rule #isSorted( (KEY : _) , (KEY' : VAL) , REST ) =>
      KEY <=String KEY' andThenBool #isSorted((KEY' : VAL) , REST)
 
 endmodule
@@ -93,7 +93,7 @@ rule <k> JOSNINPUT:JSON => #run JOSNINPUT ... </k>
 rule #failure _ => .
 
 /************************
-	running tests
+    running tests
 *************************/
 
 rule <k> #run {.JSONList} => . ... </k>
@@ -102,30 +102,30 @@ rule <k> #run {TESTID : { TEST:JSONList }, TESTS}
       ~> #run {TESTS} ...
      </k>
 
-syntax Set ::= "#execKeys"		[function]
+    yntax Set ::= "#execKeys"        [function]
 
 rule #execKeys => (SetItem("exec"))
 
-rule #run TESTID : {KEY:(VAL:JSON), NEXT , REST:JSONList} 
-     	  => #run TESTID : { NEXT, KEY:VAL , REST}
+rule #run TESTID : {KEY:(VAL:JSON), NEXT , REST:JSONList}
+              => #run TESTID : { NEXT, KEY:VAL , REST}
      requires KEY in #execKeys
 
-syntax Set ::= "#postKeys"		[function]
+    yntax Set ::= "#postKeys"        [function]
 
 rule #run TESTID : {KEY : VAL:JSON, REST} => #run TESTID : {REST} ~> #check TESTID : {KEY:VAL}
      requires KEY in #postKeys
 
-rule #postKeys => (SetItem("post"))	
+    ule #postKeys => (SetItem("post"))
 
 rule <k> #load DATA : { .JSONList } => .  ... </k>
     rule <k> #load DATA : { KEY : VALUE , REST } => #load DATA : { KEY : VALUE } ~> #load DATA : { REST } ... </k>
       requires REST =/=K .JSONList andBool DATA =/=String "transaction"
 
 
-rule <k> #run TESTID : { "exec" : EXEC:JSON} => 
-     	 #load "exec" : EXEC ~> #execute ... </k>
+rule <k> #run TESTID : { "exec" : EXEC:JSON} =>
+             #load "exec" : EXEC ~> #execute ... </k>
 
-rule <k> #load "exec" : {"code" : #solidity(EXEC:Statements)} => . ... </k>  
+rule <k> #load "exec" : {"code" : #solidity(EXEC:Statements)} => . ... </k>
      <program> _ => EXEC </program>
 
 
@@ -133,7 +133,7 @@ rule <k> #load "exec" : {"code" : #solidity(EXEC:Statements)} => . ... </k>
 
 
 /******************************
-	For parse
+    For parse
 *******************************/
 
 syntax Int ::= #parseAddr ( String ) [function]
@@ -200,7 +200,7 @@ rule <k> #check "post" : {.JSONList} => . ... </k>
      <mode> _ => "SUCCESS" </mode>
 
 rule <k> #check "post" : {"mem" : #exists(S:String, V:Value) Ms:MemStatusList, REST:JSONList}
-     	 	=> #check "post" : {"mem" : Ms} ~> #check "post" : {REST} ... </k>
+                 => #check "post" : {"mem" : Ms} ~> #check "post" : {REST} ... </k>
      <env> ... String2Id(S) |-> #storedVar( I:Int , _ , _)... </env>
      <localMem> ... I |-> V ... </localMem>
 

--- a/driver.k
+++ b/driver.k
@@ -58,7 +58,7 @@ rule #sortJSONList(.JSONList, LS)            => LS
 rule #sortJSONList(((KEY : VAL) , REST), LS)
      => #insertJSONKey((KEY : VAL), #sortJSONList(REST, LS))
 
-    yntax JSONList ::= #insertJSONKey ( JSON , JSONList )        [function]
+syntax JSONList ::= #insertJSONKey ( JSON , JSONList )        [function]
 rule #insertJSONKey( JS , .JSONList ) => JS , .JSONList
 rule #insertJSONKey( (KEY : VAL) , ((KEY' : VAL') , REST) )
      => (KEY : VAL)   , (KEY' : VAL'), REST
@@ -102,7 +102,7 @@ rule <k> #run {TESTID : { TEST:JSONList }, TESTS}
       ~> #run {TESTS} ...
      </k>
 
-    yntax Set ::= "#execKeys"        [function]
+syntax Set ::= "#execKeys"        [function]
 
 rule #execKeys => (SetItem("exec"))
 
@@ -110,12 +110,12 @@ rule #run TESTID : {KEY:(VAL:JSON), NEXT , REST:JSONList}
               => #run TESTID : { NEXT, KEY:VAL , REST}
      requires KEY in #execKeys
 
-    yntax Set ::= "#postKeys"        [function]
+syntax Set ::= "#postKeys"        [function]
 
 rule #run TESTID : {KEY : VAL:JSON, REST} => #run TESTID : {REST} ~> #check TESTID : {KEY:VAL}
      requires KEY in #postKeys
 
-    ule #postKeys => (SetItem("post"))
+rule #postKeys => (SetItem("post"))
 
 rule <k> #load DATA : { .JSONList } => .  ... </k>
     rule <k> #load DATA : { KEY : VALUE , REST } => #load DATA : { KEY : VALUE } ~> #load DATA : { REST } ... </k>

--- a/function.k
+++ b/function.k
@@ -9,17 +9,6 @@ imports SOLIDITY-SYNTAX
 imports CONFIGURATION
 imports CONTRACT
 
-/*
-syntax State
-       ::= #state(ContractInstanceSig, Map, ControlFlag, FunctionFlag)
-
-
-syntax ControlFlag
-       ::= #return(Bool,Value)
-
-syntax FunctionFlag ::= "#external" | "#internal"
-*/
-
 rule [function-definition]:
     <k> #pcsContractPart(Ct:Id, function F:Id (Ps:FParameters) FQ:FunQuantifiers returns (Rs:FParameters) {B})
             => . ... </k>
@@ -133,20 +122,6 @@ syntax SolidityItem
          | #BindInputParams(FParameters, Values)
          | #BindReturnParams(FParameters, Values)
 
-/*
-rule [External-Function-Call]:
-     <k> functionCall(C:Int; F:Id; Vs:Values) => #Call(F,Vs)  ~> #returnContract ...</k>
-     <currentAccount> #account(C1,N1) => #account(C,N) </currentAccount>
-     <env> Rho:Map => CRho </env>
-     <callStack> .List => ListItem(#state(#account(C1,N1), Rho, #return(false,#undef_Value), #external)) ... </callStack>
-     <callDepth> Dep => Dep +Int 1 </callDepth>
-     <account>
-         <acctID> #account(C,N) </acctID>
-         <acctEnv> CRho:Map </acctEnv>
-         ...
-     </account>
-*/
-
 rule [External-Function-Call]:
      <k> functionCall(C:Int; F:Id; Vs:Values) => #Call(F,Vs)  ~> #returnContract ...</k>
      <currentAccount> #account(C1,N1) => #account(C,N) </currentAccount>
@@ -195,14 +170,6 @@ rule [External-Function-Call]:
          <acctEnv> CRho:Map </acctEnv>
          ...
      </account>
-
-/*
-rule [Internal-Function-Call]:
-     <k> functionCall(F:Id; Vs:Values) => #Call(F,Vs) ~> #return ... </k>
-     <currentAccount> #account(C,N) </currentAccount>
-     <env> ENV:Map  </env>
-     <callStack> .List => ListItem(#state(#account(C,N),ENV,#return(false,#undef_Value), #internal)) ... </callStack>
-*/
 
 rule [Internal-Function-Call]:
      <k> functionCall(F:Id; Vs:Values) => #Call(F,Vs) ~> #return ... </k>
@@ -296,12 +263,6 @@ rule [Call-Function-Body]:
 rule
      <k> #CallBody(.Statements) => . ...</k>
 
-/*
-rule
-     <k> #exeStmt(S:SimpleStatement;) => S; ...</k>
-     <callStack> ListItem(#state(#account(_:Int,_:AccountId), _:Map, #return(false,_:Value), _:FunctionFlag)) ... </callStack>
-*/
-
 rule
      <k> #exeStmt(S:SimpleStatement;) => S; ...</k>
      <callState>
@@ -309,25 +270,12 @@ rule
         <returnFlag> false </returnFlag>
      </callState>
 
-/*
-rule
-     <k> #exeStmt(S:SimpleStatement;) => . ...</k>
-     <callStack> ListItem(#state(#account(_:Int,_:AccountId), _:Map, #return(true,_:Value), _:FunctionFlag)) ... </callStack>
-*/
-
 rule
      <k> #exeStmt(S:SimpleStatement;) => . ...</k>
      <callState>
         ...
         <returnFlag> true </returnFlag>
      </callState>
-
-/*
-rule [Local-Call-Return]:
-     <k> #return  => V  ... </k>
-     <callStack> ListItem(#state(C, Rho, #return(_:Bool,V:Value), #internal)) => .List ... </callStack>
-     <env> _ => Rho </env>
-*/
 
 rule [Local-Call-Return]:
      <k> #return  => V  ... </k>
@@ -372,15 +320,6 @@ rule [Local-Call-Return]:
         <returnValue> V => RETURNVALUE </returnValue>
         <isExternalFunctionCall> false => EXFUNCALL </isExternalFunctionCall>
      </callState>
-
-/*
-rule [External-Call-Return]:
-     <k> #returnContract => V ... </k>
-     <callStack> ListItem(#state(C, Rho, #return(_:Bool,V:Value), #external)) => .List ... </callStack>
-     <env> _ => Rho </env>
-     <currentAccount> _ => C  </currentAccount>
-     <callDepth> Depth => Depth -Int 1 </callDepth>
-*/
 
 rule [External-Call-Return]:
      <k> #returnContract => V ... </k>
@@ -428,12 +367,6 @@ rule [External-Call-Return]:
      </callState>
 
 
-/*
-rule [ReturnValue]:
-     <k> return V:Value  => #end_Exp ... </k>
-     <callStack> ListItem(#state(C, Rho, #return(_:Bool => true, _:Value => V), _:FunctionFlag)) ... </callStack>
-*/
-
 rule [ReturnValue]:
      <k> return V:Value  => #end_Exp ... </k>
      <callState>
@@ -441,12 +374,6 @@ rule [ReturnValue]:
         <returnFlag> _:Bool => true </returnFlag>
         <returnValue> _:Value => V </returnValue>
      </callState>
-
-/*
-rule [Return]:
-     <k> return  => #end_Exp ... </k>
-     <callStack> ListItem(#state(C, Rho, #return(_:Bool => true, _:Value), _:FunctionFlag)) ... </callStack>
-*/
 
 rule [Return]:
      <k> return  => #end_Exp ... </k>

--- a/function.k
+++ b/function.k
@@ -27,12 +27,12 @@ rule [function-definition]:
         <cname> Ct </cname>
         (.Bag =>
             <Function>
-	        <fname> F </fname>
-	        <inputParams> Ps </inputParams>
-	        <Returns> Rs </Returns>
-	        <quantifiers> FQ </quantifiers>
-	        <visibility> .K </visibility>
-	        <body> B </body>
+            <fname> F </fname>
+            <inputParams> Ps </inputParams>
+            <Returns> Rs </Returns>
+            <quantifiers> FQ </quantifiers>
+            <visibility> .K </visibility>
+            <body> B </body>
             </Function>)
          ...
     </Contract>
@@ -44,12 +44,12 @@ rule
         <cname> Ct </cname>
         (.Bag =>
             <Function>
-	        <fname> F </fname>
-	        <inputParams> Ps </inputParams>
-	        <Returns> .FParameters </Returns>
-	        <quantifiers> FQ </quantifiers>
-	        <visibility> .K </visibility>
-	        <body> B </body>
+            <fname> F </fname>
+            <inputParams> Ps </inputParams>
+            <Returns> .FParameters </Returns>
+            <quantifiers> FQ </quantifiers>
+            <visibility> .K </visibility>
+            <body> B </body>
             </Function>)
          ...
     </Contract>
@@ -61,12 +61,12 @@ rule
         <cname> Ct </cname>
         (.Bag =>
             <Function>
-	        <fname> F </fname>
-	        <inputParams> Ps </inputParams>
-	        <Returns> Rs </Returns>
-	        <quantifiers> FQ </quantifiers>
-	        <visibility> .K </visibility>
-	        <body> .Statements </body>
+            <fname> F </fname>
+            <inputParams> Ps </inputParams>
+            <Returns> Rs </Returns>
+            <quantifiers> FQ </quantifiers>
+            <visibility> .K </visibility>
+            <body> .Statements </body>
             </Function>)
          ...
     </Contract>
@@ -78,28 +78,28 @@ rule
         <cname> Ct </cname>
         (.Bag =>
             <Function>
-	        <fname> F </fname>
-	        <inputParams> Ps </inputParams>
-	        <Returns> .FParameters </Returns>
-	        <quantifiers> FQ </quantifiers>
-	        <visibility> .K </visibility>
-	        <body> .Statements </body>
+            <fname> F </fname>
+            <inputParams> Ps </inputParams>
+            <Returns> .FParameters </Returns>
+            <quantifiers> FQ </quantifiers>
+            <visibility> .K </visibility>
+            <body> .Statements </body>
             </Function>)
          ...
     </Contract>
 
-rule 
+rule
     <k> #pcsContractPart(Ct:Id, constructor (Ps:FParameters) FQ:FunQuantifiers {B}) => . ... </k>
     <Contract>
         <cname> Ct </cname>
         (.Bag =>
             <Function>
-	        <fname> String2Id("constructor") </fname>
-	        <inputParams> Ps </inputParams>
-	        <Returns> .FParameters </Returns>
-	        <quantifiers> FQ   </quantifiers>
-	        <visibility>  .K </visibility>
-	        <body> B </body>
+            <fname> String2Id("constructor") </fname>
+            <inputParams> Ps </inputParams>
+            <Returns> .FParameters </Returns>
+            <quantifiers> FQ   </quantifiers>
+            <visibility>  .K </visibility>
+            <body> B </body>
             </Function>)
          <Constructor> _ => true </Constructor>
          ...
@@ -112,19 +112,19 @@ rule
          <cname> Ct </cname>
          (.Bag =>
              <Function>
-	         <fname> String2Id("fallback") </fname>
-	         <inputParams> Ps </inputParams>
-	         <Returns> .FParameters </Returns>
-	         <quantifiers> FQ </quantifiers>
-	         <visibility> .K </visibility>
-	         <body> B </body>
+             <fname> String2Id("fallback") </fname>
+             <inputParams> Ps </inputParams>
+             <Returns> .FParameters </Returns>
+             <quantifiers> FQ </quantifiers>
+             <visibility> .K </visibility>
+             <body> B </body>
              </Function>)
           ...
     </Contract>
 
 
-syntax SolidityItem 
-       ::= #CallBody(Statements)  
+syntax SolidityItem
+       ::= #CallBody(Statements)
          | #Call(Id,Values)
          | #InitParams(FParameters, Values)
          | #InitParam(FParameter, Value)
@@ -150,16 +150,16 @@ rule [External-Function-Call]:
 rule [External-Function-Call]:
      <k> functionCall(C:Int; F:Id; Vs:Values) => #Call(F,Vs)  ~> #returnContract ...</k>
      <currentAccount> #account(C1,N1) => #account(C,N) </currentAccount>
-     <callStack> .List => 
+     <callStack> .List =>
         ListItem(
             <callState>
-                <program> PROGRAM </program> 
-                <id> ID </id>         
-                <caller> CALLER </caller>     
-                <callData> CALLDATA </callData>   
-                <callValue> CALLVALUE </callValue> 
+                <program> PROGRAM </program>
+                <id> ID </id>
+                <caller> CALLER </caller>
+                <callData> CALLDATA </callData>
+                <callValue> CALLVALUE </callValue>
                 <env> Rho </env>
-                <tenv> TENV </tenv> 
+                <tenv> TENV </tenv>
                 <localMem> LOCALMEM </localMem>
                 <gas> GAS </gas>
                 <memoryUsed>  MEMUSED </memoryUsed>
@@ -170,16 +170,16 @@ rule [External-Function-Call]:
                 <returnValue> RETURNVALUE </returnValue>
                 <isExternalFunctionCall> EXFUNCALL </isExternalFunctionCall>
             </callState>
-        ) ... 
+        ) ...
      </callStack>
      <callState>
-        <program> PROGRAM </program> 
-        <id> ID </id>         
-        <caller> CALLER => #account(C1,N1) </caller>     
-        <callData> CALLDATA </callData>   
-        <callValue> CALLVALUE </callValue> 
+        <program> PROGRAM </program>
+        <id> ID </id>
+        <caller> CALLER => #account(C1,N1) </caller>
+        <callData> CALLDATA </callData>
+        <callValue> CALLVALUE </callValue>
         <env> Rho:Map => CRho </env>
-        <tenv> TENV </tenv> 
+        <tenv> TENV </tenv>
         <localMem> LOCALMEM </localMem>
         <gas> GAS </gas>
         <memoryUsed>  MEMUSED </memoryUsed>
@@ -195,29 +195,29 @@ rule [External-Function-Call]:
          <acctEnv> CRho:Map </acctEnv>
          ...
      </account>
-     
-/* 
+
+/*
 rule [Internal-Function-Call]:
      <k> functionCall(F:Id; Vs:Values) => #Call(F,Vs) ~> #return ... </k>
      <currentAccount> #account(C,N) </currentAccount>
      <env> ENV:Map  </env>
-     <callStack> .List => ListItem(#state(#account(C,N),ENV,#return(false,#undef_Value), #internal)) ... </callStack> 
+     <callStack> .List => ListItem(#state(#account(C,N),ENV,#return(false,#undef_Value), #internal)) ... </callStack>
 */
 
 rule [Internal-Function-Call]:
      <k> functionCall(F:Id; Vs:Values) => #Call(F,Vs) ~> #return ... </k>
      <currentAccount> #account(C,N) </currentAccount>
      //<env> ENV:Map  </env>
-     <callStack> .List => 
+     <callStack> .List =>
         ListItem(
             <callState>
-                <program> PROGRAM </program> 
-                <id> ID </id>         
-                <caller> CALLER </caller>     
-                <callData> CALLDATA </callData>   
-                <callValue> CALLVALUE </callValue> 
+                <program> PROGRAM </program>
+                <id> ID </id>
+                <caller> CALLER </caller>
+                <callData> CALLDATA </callData>
+                <callValue> CALLVALUE </callValue>
                 <env> Rho </env>
-                <tenv> TENV </tenv> 
+                <tenv> TENV </tenv>
                 <localMem> LOCALMEM </localMem>
                 <gas> GAS </gas>
                 <memoryUsed>  MEMUSED </memoryUsed>
@@ -228,16 +228,16 @@ rule [Internal-Function-Call]:
                 <returnValue> RETURNVALUE </returnValue>
                 <isExternalFunctionCall> EXFUNCALL </isExternalFunctionCall>
             </callState>
-        ) ... 
-     </callStack> 
+        ) ...
+     </callStack>
      <callState>
-        <program> PROGRAM </program> 
-        <id> ID </id>         
-        <caller> CALLER => #account(C,N) </caller>     
-        <callData> CALLDATA </callData>   
-        <callValue> CALLVALUE </callValue> 
+        <program> PROGRAM </program>
+        <id> ID </id>
+        <caller> CALLER => #account(C,N) </caller>
+        <callData> CALLDATA </callData>
+        <callValue> CALLVALUE </callValue>
         <env> Rho </env>
-        <tenv> TENV </tenv> 
+        <tenv> TENV </tenv>
         <localMem> LOCALMEM </localMem>
         <gas> GAS </gas>
         <memoryUsed>  MEMUSED </memoryUsed>
@@ -250,7 +250,7 @@ rule [Internal-Function-Call]:
      </callState>
 
 
-rule 
+rule
      <k> #Call(F:Id, Vs:Values) => #BindInputParams(Ps, Vs) ~> #BindReturnParams(OPs, .Values) ~> #CallBody(Ss) ...</k>
      <currentAccount> #account(C:Int,N:AccountId) </currentAccount>
      <Contract>
@@ -271,29 +271,29 @@ rule
 rule
      <k> #BindReturnParams(OPs, Vs) => #InitParams(OPs, Vs) ...</k>
 
-     
-rule 
+
+rule
      <k> #InitParams(P:FParameter, Ps:FParameters, V:Value,Vs:Values)
-     	    => #InitParam(P, V) ~> #InitParams(Ps, Vs) ...</k>
+                => #InitParam(P, V) ~> #InitParams(Ps, Vs) ...</k>
 
-rule 
+rule
      <k> #InitParams(P:FParameter, Ps:FParameters, .Values)
-     	    => #InitParam(P, #undef_Value) ~> #InitParams(Ps, .Values) ...</k>
+                => #InitParam(P, #undef_Value) ~> #InitParams(Ps, .Values) ...</k>
 
-rule 
+rule
      <k> #InitParams(.FParameters, .Values) => . ...</k>
 
-rule 
+rule
      <k> #InitParam(T:TypeName S:StorageLocations X:Id, V) => #allocate(C, CN, #varInfo(X:Id, V:Value, T:TypeName, #mem)) ...</k>
      <currentAccount> #account(C:Int,CN:AccountId) </currentAccount>
 
-rule 
+rule
      <k> #InitParam(T:TypeName, V) => . ...</k>
 
 rule [Call-Function-Body]:
      <k> #CallBody(S:Statement Ss:Statements) => #exeStmt(S) ~> #CallBody(Ss) ...</k>
 
-rule 
+rule
      <k> #CallBody(.Statements) => . ...</k>
 
 /*
@@ -304,12 +304,12 @@ rule
 
 rule
      <k> #exeStmt(S:SimpleStatement;) => S; ...</k>
-     <callState> 
-        ... 
-        <returnFlag> false </returnFlag> 
+     <callState>
+        ...
+        <returnFlag> false </returnFlag>
      </callState>
 
-/* 
+/*
 rule
      <k> #exeStmt(S:SimpleStatement;) => . ...</k>
      <callStack> ListItem(#state(#account(_:Int,_:AccountId), _:Map, #return(true,_:Value), _:FunctionFlag)) ... </callStack>
@@ -317,30 +317,30 @@ rule
 
 rule
      <k> #exeStmt(S:SimpleStatement;) => . ...</k>
-     <callState> 
-        ... 
-        <returnFlag> true </returnFlag> 
+     <callState>
+        ...
+        <returnFlag> true </returnFlag>
      </callState>
 
 /*
 rule [Local-Call-Return]:
      <k> #return  => V  ... </k>
-     <callStack> ListItem(#state(C, Rho, #return(_:Bool,V:Value), #internal)) => .List ... </callStack> 
+     <callStack> ListItem(#state(C, Rho, #return(_:Bool,V:Value), #internal)) => .List ... </callStack>
      <env> _ => Rho </env>
 */
 
 rule [Local-Call-Return]:
      <k> #return  => V  ... </k>
-     <callStack> 
+     <callStack>
         ListItem(
             <callState>
-                <program> PROGRAM </program> 
-                <id> ID </id>         
-                <caller> CALLER </caller>     
-                <callData> CALLDATA </callData>   
-                <callValue> CALLVALUE </callValue> 
+                <program> PROGRAM </program>
+                <id> ID </id>
+                <caller> CALLER </caller>
+                <callData> CALLDATA </callData>
+                <callValue> CALLVALUE </callValue>
                 <env> Rho </env>
-                <tenv> TENV </tenv> 
+                <tenv> TENV </tenv>
                 <localMem> LOCALMEM </localMem>
                 <gas> GAS </gas>
                 <memoryUsed>  MEMUSED </memoryUsed>
@@ -351,17 +351,17 @@ rule [Local-Call-Return]:
                 <returnValue> RETURNVALUE </returnValue>
                 <isExternalFunctionCall> EXFUNCALL </isExternalFunctionCall>
             </callState>
-        ) 
-        => .List ... 
-     </callStack> 
+        )
+        => .List ...
+     </callStack>
      <callState>
-        <program> _ => PROGRAM </program> 
-        <id> _ => ID </id>         
-        <caller> _ => CALLER </caller>     
-        <callData> _ => CALLDATA </callData>   
-        <callValue> _ => CALLVALUE </callValue> 
+        <program> _ => PROGRAM </program>
+        <id> _ => ID </id>
+        <caller> _ => CALLER </caller>
+        <callData> _ => CALLDATA </callData>
+        <callValue> _ => CALLVALUE </callValue>
         <env> _ => Rho </env>
-        <tenv> _ => TENV </tenv> 
+        <tenv> _ => TENV </tenv>
         <localMem> _ => LOCALMEM </localMem>
         <gas> _ => GAS </gas>
         <memoryUsed> _ => MEMUSED </memoryUsed>
@@ -373,7 +373,7 @@ rule [Local-Call-Return]:
         <isExternalFunctionCall> false => EXFUNCALL </isExternalFunctionCall>
      </callState>
 
-/* 
+/*
 rule [External-Call-Return]:
      <k> #returnContract => V ... </k>
      <callStack> ListItem(#state(C, Rho, #return(_:Bool,V:Value), #external)) => .List ... </callStack>
@@ -385,16 +385,16 @@ rule [External-Call-Return]:
 rule [External-Call-Return]:
      <k> #returnContract => V ... </k>
      <currentAccount> _ => C  </currentAccount>
-     <callStack> 
+     <callStack>
         ListItem(
             <callState>
-                <program> PROGRAM </program> 
-                <id> ID </id>         
-                <caller> CALLER </caller>     
-                <callData> CALLDATA </callData>   
-                <callValue> CALLVALUE </callValue> 
+                <program> PROGRAM </program>
+                <id> ID </id>
+                <caller> CALLER </caller>
+                <callData> CALLDATA </callData>
+                <callValue> CALLVALUE </callValue>
                 <env> Rho </env>
-                <tenv> TENV </tenv> 
+                <tenv> TENV </tenv>
                 <localMem> LOCALMEM </localMem>
                 <gas> GAS </gas>
                 <memoryUsed>  MEMUSED </memoryUsed>
@@ -405,17 +405,17 @@ rule [External-Call-Return]:
                 <returnValue> RETURNVALUE </returnValue>
                 <isExternalFunctionCall> EXFUNCALL </isExternalFunctionCall>
             </callState>
-        ) 
-        => .List ... 
-     </callStack> 
+        )
+        => .List ...
+     </callStack>
      <callState>
-        <program> _ => PROGRAM </program> 
-        <id> _ => ID </id>         
-        <caller> C => CALLER </caller>     
-        <callData> _ => CALLDATA </callData>   
-        <callValue> _ => CALLVALUE </callValue> 
+        <program> _ => PROGRAM </program>
+        <id> _ => ID </id>
+        <caller> C => CALLER </caller>
+        <callData> _ => CALLDATA </callData>
+        <callValue> _ => CALLVALUE </callValue>
         <env> _ => Rho </env>
-        <tenv> _ => TENV </tenv> 
+        <tenv> _ => TENV </tenv>
         <localMem> _ => LOCALMEM </localMem>
         <gas> _ => GAS </gas>
         <memoryUsed> _ => MEMUSED </memoryUsed>
@@ -428,7 +428,7 @@ rule [External-Call-Return]:
      </callState>
 
 
-/* 
+/*
 rule [ReturnValue]:
      <k> return V:Value  => #end_Exp ... </k>
      <callStack> ListItem(#state(C, Rho, #return(_:Bool => true, _:Value => V), _:FunctionFlag)) ... </callStack>
@@ -436,13 +436,13 @@ rule [ReturnValue]:
 
 rule [ReturnValue]:
      <k> return V:Value  => #end_Exp ... </k>
-     <callState> 
+     <callState>
         ...
         <returnFlag> _:Bool => true </returnFlag>
         <returnValue> _:Value => V </returnValue>
      </callState>
 
-/*      
+/*
 rule [Return]:
      <k> return  => #end_Exp ... </k>
      <callStack> ListItem(#state(C, Rho, #return(_:Bool => true, _:Value), _:FunctionFlag)) ... </callStack>
@@ -450,9 +450,9 @@ rule [Return]:
 
 rule [Return]:
      <k> return  => #end_Exp ... </k>
-     <callState> 
-        ... 
-        <returnFlag> _:Bool => true </returnFlag> 
+     <callState>
+        ...
+        <returnFlag> _:Bool => true </returnFlag>
      </callState>
 
 

--- a/solidity-syntax.k
+++ b/solidity-syntax.k
@@ -6,7 +6,7 @@ import DOMAINS-SYNTAX
 import DOMAINS
 
 syntax SourceUnit ::=  PragmaDirectives ContractDefinitions
-                    
+
 syntax PragmaDirectives ::= List{PragmaDirective, ""}
 syntax PragmaDirective ::= "pragma" Id "^" Int "." Int "." Int ";"
 
@@ -89,49 +89,49 @@ syntax SolidityUint ::= "uint"
 syntax StateVariableDeclaration ::= TypeName FunQuantifiers Id ";"  [klabel(#stateVarDecl)]
                                   | TypeName FunQuantifiers Id "=" Expression ";"  [klabel(#stateVarDeclWithAssignment)]
 
-syntax FunQuantifier ::= ModifierInvocation 
+syntax FunQuantifier ::= ModifierInvocation
                        | Specifier
 
-syntax ModifierInvocation ::= Id 
-                            | FunctionCall 
+syntax ModifierInvocation ::= Id
+                            | FunctionCall
 
-syntax Specifier ::= "public" 
-                   | "internal" 
-                   | "private" 
+syntax Specifier ::= "public"
+                   | "internal"
+                   | "private"
                    | "constant"
-                   | "pure" 
-                   | "view" 
-                   | "payable" 
+                   | "pure"
+                   | "view"
+                   | "payable"
                    | "external"
 
 syntax FunQuantifiers ::= List{FunQuantifier," "}
 
 syntax FunctionDefinition ::= "function" IdentifierOrNone "(" FParameters ")" FunQuantifiers "returns" "(" FParameters ")"   Block  [prefer]
                             | "function" IdentifierOrNone "(" FParameters ")" FunQuantifiers "returns" "(" FParameters ")"  ";"    [prefer]
-                            | "function" IdentifierOrNone "(" FParameters ")" FunQuantifiers Block 
-                            | "function" IdentifierOrNone "(" FParameters ")" FunQuantifiers ";" 
-                            | "constructor" "(" FParameters ")" FunQuantifiers Block 
+                            | "function" IdentifierOrNone "(" FParameters ")" FunQuantifiers Block
+                            | "function" IdentifierOrNone "(" FParameters ")" FunQuantifiers ";"
+                            | "constructor" "(" FParameters ")" FunQuantifiers Block
 
 syntax IdentifierOrNone
-       ::= Id						
-         | ""	 [klabel(#none), onlyLabel]
-         
+          ::= Id
+            | ""	 [klabel(#none), onlyLabel]
+
 syntax FParameter ::= VariableDeclaration
-                    | TypeName  
+                    | TypeName
 
 syntax FParameters ::= List{FParameter, ","}   [klabel(#fParameters)]
 
 syntax VariableDeclaration ::= TypeName StorageLocations Id   [klabel(#varDeclaration)]
 
 syntax StorageLocations ::= List{StorageLocation, " "}
-syntax StorageLocation ::= "memory" | "storage"  
+syntax StorageLocation ::= "memory" | "storage"
 
 syntax Block ::= "{" Statements "}"   [klabel(#block)]
 syntax Statements ::= List{Statement, ""}   [klabel(#statements)]
 
-syntax Statement ::= IfStatement 
-                   | WhileStatement 
-                   | Block 
+syntax Statement ::= IfStatement
+                   | WhileStatement
+                   | Block
                    | SimpleStatement ";" [strict,klabel(#simpleStmt)]
 
 syntax SimpleStatement ::= FunctionCall | Assignment | Value | VariableDefinition | Return | NewExpression
@@ -139,62 +139,62 @@ syntax SimpleStatement ::= FunctionCall | Assignment | Value | VariableDefinitio
 syntax FunctionCall ::= Id "(" FunctionCallArguments ")" [strict(2),klabel(#localFunctionCall)]
                       | MemberAccess "(" FunctionCallArguments ")" [strict(2),klabel(#externalFunctionCall)]
                       | "functionCall" "(" Expression ";" Id ";" ExpressionList ")" [strict(1,3)]
-                      | "functionCall" "(" Id ";" ExpressionList ")" [strict(2)] 
+                      | "functionCall" "(" Id ";" ExpressionList ")" [strict(2)]
 
 
-syntax FunctionCallArguments ::= ExpressionList		
+    yntax FunctionCallArguments ::= ExpressionList
                                | "{" NameValueList "}" [strict]
 
 syntax ExpressionList ::= List{Expression, ","}    [strict]
 
 syntax NameValue ::= Id ":" Expression        [strict(2)]
 syntax NameValueList ::= List{NameValue, ","} [strict]
-   
-syntax Assignment ::= Expression "=" Expression  [strict(2), klabel(#assign)]     
+
+syntax Assignment ::= Expression "=" Expression  [strict(2), klabel(#assign)]
 
 syntax VariableDefinition ::= "var" Id
                             | VariableDeclaration
                             | VariableDeclaration "=" Expression    [strict(2)]
 
-syntax KResult ::= Value | Values    
+syntax KResult ::= Value | Values
 
 syntax Value
-       ::= Bool | Int | String 
+       ::= Bool | Int | String
 
 syntax Values
        ::= List{Value, ","}
 
-syntax ExpressionList ::= Values 
+syntax ExpressionList ::= Values
 
 syntax Return ::= "return" Expression [strict]
                 | "return"
-              
-       
-syntax NewExpression ::= "new" Id "(" ExpressionList ")"   
+
+
+syntax NewExpression ::= "new" Id "(" ExpressionList ")"
 
 syntax Expression ::= Id | Value
-                    | NewExpression   
-                    | FunctionCall  
+                    | NewExpression
+                    | FunctionCall
                     > left:
-	              Expression "*" Expression			[klabel(#multexp),strict,left]
-	            | Expression "/" Expression			[klabel(#divtexp),strict,left]
-	            > left:
-	              Expression "+" Expression			[klabel(#addexp),strict,left]
-	            | Expression "-" Expression			[klabel(#subexp),strict,left]
-	            > left:
-	              Expression "<" Expression			[klabel(#less),seqstrict,left]
-	            | Expression "<=" Expression			[klabel(#leq),seqstrict,left]
-	            | Expression ">" Expression			[klabel(#great),seqstrict,left]
-	            | Expression ">=" Expression			[klabel(#geq),seqstrict,left]
-     
-syntax IfStatement ::= "if" "(" Expression ")" Statement "else" Statement [strict(1)] 
+                  Expression "*" Expression			[klabel(#multexp),strict,left]
+                | Expression "/" Expression			[klabel(#divtexp),strict,left]
+                > left:
+                  Expression "+" Expression			[klabel(#addexp),strict,left]
+                | Expression "-" Expression			[klabel(#subexp),strict,left]
+                > left:
+                  Expression "<" Expression			[klabel(#less),seqstrict,left]
+                | Expression "<=" Expression			[klabel(#leq),seqstrict,left]
+                | Expression ">" Expression			[klabel(#great),seqstrict,left]
+                | Expression ">=" Expression			[klabel(#geq),seqstrict,left]
+
+syntax IfStatement ::= "if" "(" Expression ")" Statement "else" Statement [strict(1)]
                      | "if" "(" Expression ")" Statement [strict(1)]
 
 syntax WhileStatement ::= "while" "(" Expression ")" Statement
 
 syntax Identifiers ::= List{Id, ","}        [klabel(#identifiers)]
 
-syntax MemberAccess ::= Expression "." Id		[klabel(#memberAccess)]
+    yntax MemberAccess ::= Expression "." Id		[klabel(#memberAccess)]
 
 syntax AccountId
        ::=  Id | "#Testing-Engine#"
@@ -213,7 +213,7 @@ syntax VarInfo
 syntax MemOperation
         ::= #read(Id)
           | #write(Id, Expression) [strict(2)]
-          | #allocate(Int, AccountId, VarInfo)	
+             | #allocate(Int, AccountId, VarInfo)
 
 syntax MemFlag
        ::= "#mem"
@@ -222,7 +222,7 @@ syntax MemFlag
 syntax Exec
        ::= "#execute"
 
-syntax SolidityItem 
+syntax SolidityItem
        ::= #exeStmt(Statement)
 
 endmodule

--- a/solidity-syntax.k
+++ b/solidity-syntax.k
@@ -114,7 +114,7 @@ syntax FunctionDefinition ::= "function" IdentifierOrNone "(" FParameters ")" Fu
 
 syntax IdentifierOrNone
           ::= Id
-            | ""	 [klabel(#none), onlyLabel]
+            | ""     [klabel(#none), onlyLabel]
 
 syntax FParameter ::= VariableDeclaration
                     | TypeName
@@ -142,7 +142,7 @@ syntax FunctionCall ::= Id "(" FunctionCallArguments ")" [strict(2),klabel(#loca
                       | "functionCall" "(" Id ";" ExpressionList ")" [strict(2)]
 
 
-    yntax FunctionCallArguments ::= ExpressionList
+syntax FunctionCallArguments ::= ExpressionList
                                | "{" NameValueList "}" [strict]
 
 syntax ExpressionList ::= List{Expression, ","}    [strict]
@@ -176,16 +176,16 @@ syntax Expression ::= Id | Value
                     | NewExpression
                     | FunctionCall
                     > left:
-                  Expression "*" Expression			[klabel(#multexp),strict,left]
-                | Expression "/" Expression			[klabel(#divtexp),strict,left]
+                  Expression "*" Expression            [klabel(#multexp),strict,left]
+                | Expression "/" Expression            [klabel(#divtexp),strict,left]
                 > left:
-                  Expression "+" Expression			[klabel(#addexp),strict,left]
-                | Expression "-" Expression			[klabel(#subexp),strict,left]
+                  Expression "+" Expression            [klabel(#addexp),strict,left]
+                | Expression "-" Expression            [klabel(#subexp),strict,left]
                 > left:
-                  Expression "<" Expression			[klabel(#less),seqstrict,left]
-                | Expression "<=" Expression			[klabel(#leq),seqstrict,left]
-                | Expression ">" Expression			[klabel(#great),seqstrict,left]
-                | Expression ">=" Expression			[klabel(#geq),seqstrict,left]
+                  Expression "<" Expression            [klabel(#less),seqstrict,left]
+                | Expression "<=" Expression            [klabel(#leq),seqstrict,left]
+                | Expression ">" Expression            [klabel(#great),seqstrict,left]
+                | Expression ">=" Expression            [klabel(#geq),seqstrict,left]
 
 syntax IfStatement ::= "if" "(" Expression ")" Statement "else" Statement [strict(1)]
                      | "if" "(" Expression ")" Statement [strict(1)]
@@ -194,7 +194,7 @@ syntax WhileStatement ::= "while" "(" Expression ")" Statement
 
 syntax Identifiers ::= List{Id, ","}        [klabel(#identifiers)]
 
-    yntax MemberAccess ::= Expression "." Id		[klabel(#memberAccess)]
+syntax MemberAccess ::= Expression "." Id        [klabel(#memberAccess)]
 
 syntax AccountId
        ::=  Id | "#Testing-Engine#"

--- a/solidity.k
+++ b/solidity.k
@@ -15,7 +15,7 @@ imports CONTRACT
 imports EXPRESSION
 imports STATEMENT
 
-rule 
+rule
     <k> #execute => P ... </k>
     <program> P:K </program>
 


### PR DESCRIPTION
I didn't take care of all formatting issues, but focused on the ones mentioned above.